### PR TITLE
Changing dataflow to customize number of characters to be tokenized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "google-utility-sync-data",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-utility-sync-data",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "Utilities to work with async data on google platform.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/common/helper/DataFlowHelper.js
+++ b/src/common/helper/DataFlowHelper.js
@@ -52,6 +52,7 @@ class DataFlowHelper {
           pubSubErrorNotificationTopic: `projects/${project}/topics/handleErrors`,
           pubSubSuccessNotificationTopic: `projects/${project}/topics/postExecution`,
           columnsToConsiderInKeywords: context.columnsToConsiderInKeywords,
+          minTokenSize: context.minTokenSize,
         },
         environment: {
           tempLocation: `gs://${bucket}/temp`,


### PR DESCRIPTION
Now Dataflow will optionally receive a minimum token size (if it doesn't receive this parameter, it will continue processing as previously (using the default size).

Other PR related to this change:
https://bitbucket.org/ciandt_it/google-sumo-dataflow/pull-requests/4/wovn-1221-changing-dataflow-to-customize/diff

Important: Ramon will define better moment to merge this change